### PR TITLE
test: add LMDE (gigi) detection support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,8 @@ detect_wlroots_version() {
     if [ -f "$os_release_file" ]; then
         version_codename=$(grep -oP 'VERSION_CODENAME=\K.*' "$os_release_file" 2>/dev/null || echo "")
     fi
-    if [ "$version_codename" = "trixie" ]; then
+    if [ "$version_codename" = "trixie" ] || [ "$version_codename" = "gigi" ]; then
+        # LMDE 7 (gigi) is based on Trixie, so it uses wlroots 0.18 too
         WLROOTS_VERSION="0.18"
         NEED_XML_CURL=true
     else

--- a/tests/test_debian_detection.sh
+++ b/tests/test_debian_detection.sh
@@ -42,6 +42,10 @@ echo "--- Trixie check ---"
 source_contains "checks for trixie" 'trixie'
 
 echo ""
+echo "--- LMDE (gigi) check ---"
+source_contains "checks for gigi" 'gigi'
+
+echo ""
 echo "--- Output variables ---"
 source_contains "sets WLROOTS_VERSION" 'WLROOTS_VERSION'
 source_contains "sets NEED_XML_CURL" 'NEED_XML_CURL'
@@ -72,6 +76,21 @@ if echo "$trixie_result" | grep -q 'WLROOTS_VERSION=0.18' && echo "$trixie_resul
     pass=$((pass + 1))
 else
     echo "  FAIL: Trixie detection got: $trixie_result"
+    fail=$((fail + 1))
+fi
+rm -rf "$tmpdir"
+tmpdir=""
+
+# LMDE (gigi) case — based on Trixie, also uses wlroots 0.18
+echo "  Testing LMDE (gigi) detection..."
+tmpdir=$(mktemp -d)
+echo 'VERSION_CODENAME=gigi' > "$tmpdir/os-release"
+gigi_result=$(run_detection "$tmpdir/os-release")
+if echo "$gigi_result" | grep -q 'WLROOTS_VERSION=0.18' && echo "$gigi_result" | grep -q 'NEED_XML_CURL=true'; then
+    echo "  PASS: Gigi sets version 0.18 and NEED_XML_CURL=true"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: Gigi detection got: $gigi_result"
     fail=$((fail + 1))
 fi
 rm -rf "$tmpdir"


### PR DESCRIPTION
Add test cases and detection logic for LMDE 7 (gigi) which is
based on Trixie and requires the same wlroots 0.18 configuration.
Update the version codename check to recognize gigi alongside
trixie and set appropriate build variables.